### PR TITLE
Set default roomid to stop console warnings

### DIFF
--- a/static/scripts/lang.js
+++ b/static/scripts/lang.js
@@ -60,7 +60,7 @@ export const messages =
             school_rouka: "学校 廊下",
             school_international: "学校 国際科教室",
             school_pc: "学校 パソコンルーム",
-            enkai: "宴会場",
+            enkai: "宴会場"
         }
     },
     en:
@@ -122,7 +122,7 @@ export const messages =
             radio_gakuya: "Radio Studio: Dressing Room",
             radio_backstage: "Radio Studio: Greenroom",
             yatai: "Sushi Vendor",
-            kaidan: "Hilltop Stairway",
+            kaidan: "Hilltop Stairway"
         }
     }
 }

--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -31,7 +31,7 @@ const vueApp = new Vue({
 
         // Possibly redundant data:
         username: "",
-        roomid: "",
+        roomid: "admin_st",
         serverStats: {
             userCount: 0
         },


### PR DESCRIPTION
I didn't see the warnings because my console was filled with these cross site Cookie warnings for stuff that I had running on localhost before. Cookies deleted and it seems to have stopped those now.