### PR TITLE
Stop errors about image heights

### DIFF
--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -577,7 +577,7 @@ const vueApp = new Vue({
                         let temporaryBodgeYOffset = 0;
                         if (o.o.offset)
                         {
-                            if (!this.currentRoom.backgroundImage || !this.currentRoom.backgroundImage.height) continue;
+                            if (!o.o.image || !this.currentRoom.backgroundImage) continue;
                             temporaryBodgeYOffset = (o.o.image.height * globalScale * (o.o.scale * this.currentRoom.scale)) + (this.canvasDimensions.h - this.currentRoom.backgroundImage.height * globalScale * this.currentRoom.scale);
                         }
                         


### PR DESCRIPTION
Should hopefully do it
`if (!o.o.image || !this.currentRoom.backgroundImage) continue;`
Realised it doesn't need to check the height. it's the height of an undefined property that was the issue only I think. the height is available at the same time the image becomes available.

