### PR TITLE
Split canvas into background canvas and foreground canvas

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -59,7 +59,7 @@
                 {{ $t("msg.page_refresh_required") }}
             </h2>
             <div id="canvas-container">
-                <canvas id="room-canvas-background" tabindex="1"></canvas>
+                <canvas id="room-canvas-background"></canvas>
                 <canvas id="room-canvas-foreground" tabindex="1"
                     v-on:keydown="handleCanvasKeydown($event)"
                     v-on:mousedown="handleCanvasMousedown($event)"

--- a/static/index.html
+++ b/static/index.html
@@ -59,7 +59,9 @@
                 {{ $t("msg.page_refresh_required") }}
             </h2>
             <div id="canvas-container">
-                <canvas id="room-canvas" tabindex="1" v-on:keydown="handleCanvasKeydown($event)"
+                <canvas id="room-canvas-background" tabindex="1"></canvas>
+                <canvas id="room-canvas-foreground" tabindex="1"
+                    v-on:keydown="handleCanvasKeydown($event)"
                     v-on:mousedown="handleCanvasMousedown($event)"
                     v-on:mousemove="handleCanvasMousemove($event)"></canvas>
                 <div id="infobox-container">

--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -584,12 +584,6 @@ const vueApp = new Vue({
                     {
                         // draw users only when the room is fully loaded, so that the "physical position" calculations
                         // are done with the correct room's data.
-                        this.drawCenteredText(
-                            context,
-                            o.o.name,
-                            (o.o.currentPhysicalPositionX + 40) + canvasOffset.x,
-                            (o.o.currentPhysicalPositionY - 95) + canvasOffset.y
-                        );
 
                         let drawFunc;
 

--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -517,8 +517,7 @@ const vueApp = new Vue({
             
             context.fillStyle = this.currentRoom.backgroundColor;
             context.fillRect(0, 0, this.canvasDimensions.w, this.canvasDimensions.h);
-
-            // draw background
+            
             if (!this.currentRoom.backgroundOffset)
                 this.currentRoom.backgroundOffset = { x: 0, y: 0 }
             this.drawImage(

--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -42,7 +42,10 @@ const vueApp = new Vue({
         streams: [],
         areaId: "gen", // 'gen' or 'for'
 
-        isRedrawRequired: false,
+        contextBackground: null,
+        contextForeground: null,
+        isBackgroundRedrawRequired: false,
+        isForegroundRedrawRequired: false,
         isDraggingCanvas: false,
         canvasDragStartPoint: null,
         canvasDragOffset: null,
@@ -99,7 +102,8 @@ const vueApp = new Vue({
 
             window.addEventListener("resize", () =>
             {
-                this.isRedrawRequired = true
+                this.isBackgroundRedrawRequired = true;
+                this.isForegroundRedrawRequired = true;
             })
             
             await Promise.all(Object.values(characters).map(c => c.loadImages()));
@@ -123,6 +127,11 @@ const vueApp = new Vue({
             await this.connectToServer(this.username);
 
             this.isLoggingIn = false;
+            
+            this.contextBackground = document.getElementById("room-canvas-background")
+                .getContext("2d", {alpha: false});
+            this.contextForeground = document.getElementById("room-canvas-foreground")
+                .getContext("2d");
             this.paint();
 
             this.soundEffectVolume = localStorage.getItem(this.areaId + "soundEffectVolume") || 0
@@ -163,7 +172,7 @@ const vueApp = new Vue({
             {
                 if (this.roomLoadId != roomLoadId) return;
                 this.currentRoom.backgroundImage = image;
-                this.isRedrawRequired = true;
+                this.isBackgroundRedrawRequired = true;
             });
             for (const o of this.currentRoom.objects)
             {
@@ -189,7 +198,7 @@ const vueApp = new Vue({
                             o.physicalPositionX = x + (o.xOffset || 0);
                             o.physicalPositionY = y + (o.yOffset || 0);
                         }
-                        this.isRedrawRequired = true;
+                        this.isForegroundRedrawRequired = true;
                     }
                 );
             }
@@ -201,7 +210,7 @@ const vueApp = new Vue({
             // Force update of user coordinates using the current room's logics (origin coordinates, etc)
             this.forcePhysicalPositionRefresh();
 
-            document.getElementById("room-canvas").focus();
+            document.getElementById("room-canvas-foreground").focus();
             this.justSpawnedToThisRoom = true;
             this.isLoadingRoom = false;
             this.requestedRoomChange = false;
@@ -344,13 +353,13 @@ const vueApp = new Vue({
             {
                 document.getElementById("login-sound").play();
                 this.addUser(user);
-                this.isRedrawRequired = true;
+                this.isForegroundRedrawRequired = true;
             });
 
             this.socket.on("server-user-left-room", (userId) =>
             {
                 if (userId != this.myUserID) delete this.users[userId];
-                this.isRedrawRequired = true;
+                this.isForegroundRedrawRequired = true;
             });
 
             this.socket.on("server-not-ok-to-stream", (reason) =>
@@ -432,13 +441,12 @@ const vueApp = new Vue({
             );
             this.users[userDTO.id] = newUser;
         },
-        drawImage: function (image, x, y, scale)
+        drawImage: function (context, image, x, y, scale)
         {
             if (!image) return; // image might be null when rendering a room that hasn't been fully loaded
 
             if (!scale) scale = 1;
-
-            const context = document.getElementById("room-canvas").getContext("2d");
+            
             context.drawImage(
                 image,
                 Math.round(x),
@@ -447,16 +455,14 @@ const vueApp = new Vue({
                 Math.round(image.height * globalScale * scale)
             );
         },
-        drawHorizontallyFlippedImage: function (image, x, y)
+        drawHorizontallyFlippedImage: function (context, image, x, y)
         {
-            const context = document.getElementById("room-canvas").getContext("2d");
             context.scale(-1, 1);
-            this.drawImage(image, -x - image.width / 2, y);
+            this.drawImage(context, image, -x - image.width / 2, y);
             context.setTransform(1, 0, 0, 1, 0, 0); // clear transformation
         },
-        drawCenteredText: function (text, x, y)
+        drawCenteredText: function (context, text, x, y)
         {
-            const context = document.getElementById("room-canvas").getContext("2d");
             // const width = context.measureText(text).width
             context.font = "bold 13px Arial, Helvetica, sans-serif";
             context.textBaseline = "bottom";
@@ -464,16 +470,18 @@ const vueApp = new Vue({
             context.fillStyle = "blue";
             context.fillText(text, x, y);
         },
-        detectCanvasResize: function (canvasElement, context)
+        detectCanvasResize: function ()
         {
-            if (this.canvasDimensions.w != canvasElement.offsetWidth ||
-                this.canvasDimensions.h != canvasElement.offsetHeight)
+            if (this.canvasDimensions.w != this.contextBackground.canvas.offsetWidth ||
+                this.canvasDimensions.h != this.contextBackground.canvas.offsetHeight)
             {
-                this.canvasDimensions.w = canvasElement.offsetWidth;
-                this.canvasDimensions.h = canvasElement.offsetHeight;
+                this.canvasDimensions.w = this.contextBackground.canvas.offsetWidth;
+                this.canvasDimensions.h = this.contextBackground.canvas.offsetHeight;
 
-                context.canvas.width = this.canvasDimensions.w;
-                context.canvas.height = this.canvasDimensions.h;
+                this.contextBackground.canvas.width = this.canvasDimensions.w;
+                this.contextBackground.canvas.height = this.canvasDimensions.h;
+                this.contextForeground.canvas.width = this.canvasDimensions.w;
+                this.contextForeground.canvas.height = this.canvasDimensions.h;
             }
         },
         getCanvasOffset: function ()
@@ -502,8 +510,153 @@ const vueApp = new Vue({
 
             return canvasOffset;
         },
+        
+        paintBackground: function(canvasOffset)
+        {
+            const context = this.contextBackground;
+            
+            context.fillStyle = this.currentRoom.backgroundColor;
+            context.fillRect(0, 0, this.canvasDimensions.w, this.canvasDimensions.h);
 
-        // TODO: Refactor this entire function
+            // draw background
+            if (!this.currentRoom.backgroundOffset)
+                this.currentRoom.backgroundOffset = { x: 0, y: 0 }
+            this.drawImage(
+                context,
+                this.currentRoom.backgroundImage,
+                0 + this.currentRoom.backgroundOffset.x + canvasOffset.x,
+                this.canvasDimensions.h + this.currentRoom.backgroundOffset.y + canvasOffset.y,
+                this.currentRoom.scale
+            );
+        },
+        
+        paintForeground: function(canvasOffset)
+        {
+            const context = this.contextForeground;
+            
+            context.clearRect(0, 0, this.canvasDimensions.w, this.canvasDimensions.h);
+            
+            const allObjects = this.currentRoom.objects
+                .map(o => ({
+                    o,
+                    type: "room-object",
+                    priority: o.x + 1 + (this.currentRoom.size.y - o.y),
+                }))
+                .concat(
+                    Object.values(this.users).map(o => ({
+                        o,
+                        type: "user",
+                        priority:
+                            o.logicalPositionX +
+                            1 +
+                            (this.currentRoom.size.y - o.logicalPositionY),
+                    }))
+                )
+                .sort((a, b) =>
+                {
+                    if (a.priority < b.priority) return -1;
+                    if (a.priority > b.priority) return 1;
+                    return 0;
+                });
+
+            for (const o of allObjects)
+            {
+                if (o.type == "room-object")
+                {
+                    let temporaryBodgeYOffset = 0;
+                    if (o.o.offset)
+                    {
+                        if (!o.o.image || !this.currentRoom.backgroundImage) continue;
+                        temporaryBodgeYOffset = (o.o.image.height * globalScale * (o.o.scale * this.currentRoom.scale)) + (this.canvasDimensions.h - this.currentRoom.backgroundImage.height * globalScale * this.currentRoom.scale);
+                    }
+                    
+                    this.drawImage(
+                        context,
+                        o.o.image,
+                        o.o.physicalPositionX + canvasOffset.x,
+                        o.o.physicalPositionY + canvasOffset.y + temporaryBodgeYOffset,
+                        this.currentRoom.scale * o.o.scale
+                    );
+                } // o.type == "user"
+                else
+                {
+                    if (!this.isLoadingRoom)
+                    {
+                        // draw users only when the room is fully loaded, so that the "physical position" calculations
+                        // are done with the correct room's data.
+                        this.drawCenteredText(
+                            context,
+                            o.o.name,
+                            (o.o.currentPhysicalPositionX + 40) + canvasOffset.x,
+                            (o.o.currentPhysicalPositionY - 95) + canvasOffset.y
+                        );
+
+                        let drawFunc;
+
+                        switch (o.o.direction)
+                        {
+                            case "up": case "right": drawFunc = this.drawImage; break;
+                            case "down": case "left": drawFunc = this.drawHorizontallyFlippedImage; break;
+                        }
+
+                        // context.globalAlpha = 0.3
+
+                        drawFunc(
+                            context,
+                            o.o.getCurrentImage(this.currentRoom),
+                            o.o.currentPhysicalPositionX + canvasOffset.x,
+                            o.o.currentPhysicalPositionY + canvasOffset.y
+                        );
+
+                        // context.globalAlpha = 1
+                    }
+
+
+                }
+            }
+
+            // Draw usernames on top of everything else
+            for (const o of allObjects.filter(o => o.type == "user"))
+            {
+                if (!this.isLoadingRoom)
+                {
+                    this.drawCenteredText(
+                        context,
+                        o.o.name,
+                        (o.o.currentPhysicalPositionX + 40) + canvasOffset.x,
+                        (o.o.currentPhysicalPositionY - 95) + canvasOffset.y
+                    );
+                }
+
+                o.o.spendTime(this.currentRoom);
+            }
+
+            if (localStorage.getItem("enableGridNumbers") == "true")
+            {
+                context.font = "bold 13px Arial, Helvetica, sans-serif";
+                context.textBaseline = "bottom";
+                context.textAlign = "right";
+
+                for (let x = 0; x < this.currentRoom.size.x; x++)
+                    for (let y = 0; y < this.currentRoom.size.y; y++)
+                    {
+                        context.fillStyle = this.currentRoom.blocked.find(b => b.x == x && b.y == y)
+                            ? "red"
+                            : "blue";
+                        const realCoord = calculateRealCoordinates(
+                            this.currentRoom,
+                            x,
+                            y
+                        );
+                        context.fillText(
+                            x + "," + y,
+                            realCoord.x + 40,
+                            realCoord.y - 20
+                        );
+                    }
+            }
+        },
+        
         paint: function (timestamp)
         {
 
@@ -515,153 +668,31 @@ const vueApp = new Vue({
                     this.forceUserInstantMove = false;
                 }
 
-                const canvasElement = document.getElementById("room-canvas");
-                const context = canvasElement.getContext("2d");
-
-                this.detectCanvasResize(canvasElement, context);
-
-                let isRedrawRequired = this.isRedrawRequired
-                    || this.isDraggingCanvas
-                    || Object.values(this.users).find(u => u.checkIfRedrawRequired());
-
-                if (!isRedrawRequired)
-                {
-                    requestAnimationFrame(this.paint);
-                    return;
-                }
-
-                this.isRedrawRequired = false;
-
-                context.fillStyle = this.currentRoom.backgroundColor;
-                context.fillRect(0, 0, this.canvasDimensions.w, this.canvasDimensions.h);
-
+                this.detectCanvasResize();
+                
                 const canvasOffset = this.getCanvasOffset();
-
-                // draw background
-                if (!this.currentRoom.backgroundOffset)
-                    this.currentRoom.backgroundOffset = { x: 0, y: 0 }
-                this.drawImage(
-                    this.currentRoom.backgroundImage,
-                    0 + this.currentRoom.backgroundOffset.x + canvasOffset.x,
-                    this.canvasDimensions.h + this.currentRoom.backgroundOffset.y + canvasOffset.y,
-                    this.currentRoom.scale
-                );
-
-                const allObjects = this.currentRoom.objects
-                    .map(o => ({
-                        o,
-                        type: "room-object",
-                        priority: o.x + 1 + (this.currentRoom.size.y - o.y),
-                    }))
-                    .concat(
-                        Object.values(this.users).map(o => ({
-                            o,
-                            type: "user",
-                            priority:
-                                o.logicalPositionX +
-                                1 +
-                                (this.currentRoom.size.y - o.logicalPositionY),
-                        }))
-                    )
-                    .sort((a, b) =>
-                    {
-                        if (a.priority < b.priority) return -1;
-                        if (a.priority > b.priority) return 1;
-                        return 0;
-                    });
-
-                for (const o of allObjects)
+                
+                
+                const usersRequiringRedraw = [];
+                for (const [userId, user] of Object.entries(this.users))
+                    if(user.checkIfRedrawRequired()) usersRequiringRedraw.push(userId);
+                
+                if (this.isBackgroundRedrawRequired
+                    || this.isDraggingCanvas
+                    || (!this.currentRoom.needsFixedCamera && usersRequiringRedraw.includes(this.myUserID)))
                 {
-                    if (o.type == "room-object")
-                    {
-                        let temporaryBodgeYOffset = 0;
-                        if (o.o.offset)
-                        {
-                            if (!o.o.image || !this.currentRoom.backgroundImage) continue;
-                            temporaryBodgeYOffset = (o.o.image.height * globalScale * (o.o.scale * this.currentRoom.scale)) + (this.canvasDimensions.h - this.currentRoom.backgroundImage.height * globalScale * this.currentRoom.scale);
-                        }
-                        
-                        this.drawImage(
-                            o.o.image,
-                            o.o.physicalPositionX + canvasOffset.x,
-                            o.o.physicalPositionY + canvasOffset.y + temporaryBodgeYOffset,
-                            this.currentRoom.scale * o.o.scale
-                        );
-                    } // o.type == "user"
-                    else
-                    {
-                        if (!this.isLoadingRoom)
-                        {
-                            // draw users only when the room is fully loaded, so that the "physical position" calculations
-                            // are done with the correct room's data.
-                            this.drawCenteredText(
-                                o.o.name,
-                                (o.o.currentPhysicalPositionX + 40) + canvasOffset.x,
-                                (o.o.currentPhysicalPositionY - 95) + canvasOffset.y
-                            );
-
-                            let drawFunc;
-
-                            switch (o.o.direction)
-                            {
-                                case "up": case "right": drawFunc = this.drawImage; break;
-                                case "down": case "left": drawFunc = this.drawHorizontallyFlippedImage; break;
-                            }
-
-                            // context.globalAlpha = 0.3
-
-                            drawFunc(
-                                o.o.getCurrentImage(this.currentRoom),
-                                o.o.currentPhysicalPositionX + canvasOffset.x,
-                                o.o.currentPhysicalPositionY + canvasOffset.y
-                            );
-
-                            // context.globalAlpha = 1
-                        }
-
-
-                    }
+                    this.paintBackground(canvasOffset);
+                    this.isBackgroundRedrawRequired = false;
                 }
-
-                // Draw usernames on top of everything else
-                for (const o of allObjects.filter(o => o.type == "user"))
+            
+                if (this.isForegroundRedrawRequired
+                    || this.isDraggingCanvas
+                    || usersRequiringRedraw.length)
                 {
-                    if (!this.isLoadingRoom)
-                    {
-                        this.drawCenteredText(
-                            o.o.name,
-                            (o.o.currentPhysicalPositionX + 40) + canvasOffset.x,
-                            (o.o.currentPhysicalPositionY - 95) + canvasOffset.y
-                        );
-                    }
-
-                    o.o.spendTime(this.currentRoom);
+                    this.paintForeground(canvasOffset);
+                    this.isForegroundRedrawRequired = false;
                 }
-
-                if (localStorage.getItem("enableGridNumbers") == "true")
-                {
-                    context.font = "bold 13px Arial, Helvetica, sans-serif";
-                    context.textBaseline = "bottom";
-                    context.textAlign = "right";
-
-                    for (let x = 0; x < this.currentRoom.size.x; x++)
-                        for (let y = 0; y < this.currentRoom.size.y; y++)
-                        {
-                            context.fillStyle = this.currentRoom.blocked.find(b => b.x == x && b.y == y)
-                                ? "red"
-                                : "blue";
-                            const realCoord = calculateRealCoordinates(
-                                this.currentRoom,
-                                x,
-                                y
-                            );
-                            context.fillText(
-                                x + "," + y,
-                                realCoord.x + 40,
-                                realCoord.y - 20
-                            );
-                        }
-                }
+                
                 this.changeRoomIfSteppingOnDoor();
             } catch (err)
             {
@@ -717,7 +748,7 @@ const vueApp = new Vue({
                     u.logicalPositionY,
                     u.direction
                 );
-            this.isRedrawRequired = true;
+            this.isForegroundRedrawRequired = true;
         },
         sendNewPositionToServer: function (direction)
         {

--- a/static/style/main.css
+++ b/static/style/main.css
@@ -205,16 +205,29 @@ video {
     height: 100%;
 }
 
-#room-canvas
+#room-canvas-background
 {
+    z-index: -1;
+}
+
+#room-canvas-foreground
+{
+    z-index: 0;
+}
+
+#room-canvas-background,
+#room-canvas-foreground
+{
+    position: absolute;
     width: 100%;
-    height: 511px;
+    height: 100%;
 }
 
 #canvas-container
 {
     position: relative;
-    max-width: 700px;
+    width: 700px;
+    height: 511px;
 }
 
 #toolbar


### PR DESCRIPTION
Another pull request attempt

This is two canvases layered on top of each other. You can see the background canvas through the transparent parts of the foreground canvas.

The diff looks a bit mad with all the additions and deletions, but it's mainly just moving code out of paint() into paintBackground() and paintForeground(). You'll find most of it still in the same order in those two functions. paint() is now just there to decide when those two functions need to be called.
A bit of refactoring in a way.

If you're just stood there doing nothing and the background isn't moving, only paintForeground() is called when others are moving or animations are going on. paintForeground() initially calls a clearRect to make the whole foreground canvas transparent again,  then draws the objects and users on top. clearRect is a lot faster and less cpu intensive than drawing the background color and background image.

Also removal of the duplicated above char name drawing.