### PR TITLE
Keep user names as empty strings and display as localised anon

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -93,7 +93,7 @@ io.on("connection", function (socket: any)
                 if (rooms[user.roomId].forcedAnonymous)
                 {
                     const anonymousUser = cloneDeep(p)
-                    anonymousUser.name = user.areaId == "gen" ? "名無しさん" : "Anonymous"
+                    anonymousUser.name = ""
                     return anonymousUser
                 }
                 else
@@ -113,7 +113,7 @@ io.on("connection", function (socket: any)
         if (currentRoom.forcedAnonymous)
         {
             const anonymousUser = cloneDeep(user)
-            anonymousUser.name = user.areaId == "gen" ? "名無しさん" : "Anonymous"
+            anonymousUser.name = ""
             socket.to(user.areaId + currentRoom.id).emit("server-user-joined-room", anonymousUser);
         }
         else
@@ -164,7 +164,7 @@ io.on("connection", function (socket: any)
             socket.join(user.areaId)
             socket.join(user.areaId + currentRoom.id)
 
-            log.info("userId:", userId, "name:", user.name, "disconnectionTime:", user.disconnectionTime);
+            log.info("userId:", userId, "name:", "<" + user.name + ">", "disconnectionTime:", user.disconnectionTime);
 
             user.isGhost = false
             user.disconnectionTime = null
@@ -191,9 +191,7 @@ io.on("connection", function (socket: any)
 
             msg = msg.substr(0, 500)
 
-            const userName = user.name
-
-            log.info("MSG:", user.id, user.areaId, user.roomId, userName + ": " + msg);
+            log.info("MSG:", user.id, user.areaId, user.roomId, "<" + user.name + ">" + ": " + msg);
 
             user.lastAction = Date.now()
 
@@ -674,7 +672,7 @@ app.post("/login", (req, res) =>
     try
     {
         let { userName, characterId, areaId } = req.body
-        if (!userName)
+        if (typeof userName !== "string")
         {
             res.statusCode = 500
             res.end("please specify a username")
@@ -691,7 +689,7 @@ app.post("/login", (req, res) =>
             processedUserName = processedUserName + "◆" + tripcode(userName.substr(n + 1));
 
         const user = addNewUser(processedUserName, characterId, areaId);
-        log.info("Logged in", user.id, user.name)
+        log.info("Logged in", user.id, "<" + user.name + ">")
         res.json(user.id)
     }
     catch (e)
@@ -796,7 +794,7 @@ function clearStream(user: Player)
 
 function disconnectUser(user: Player)
 {
-    log.info("Removing user ", user.id, user.name, user.areaId)
+    log.info("Removing user ", user.id, "<" + user.name + ">", user.areaId)
     clearStream(user)
     removeUser(user)
 

--- a/static/index.html
+++ b/static/index.html
@@ -187,7 +187,7 @@
                                 v-on:click="selectRoomForRula(room.id)">
                                 <td>{{ $t("room." + room.id) }}</td>
                                 <td>{{ room.userCount }}</td>
-                                <td>{{ room.streamers.join(", ") }}</td>
+                                <td>{{ room.streamerDisplayNames.join(", ") }}</td>
                             </tr>
                         </tbody>
                     </table>

--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -122,8 +122,6 @@ const vueApp = new Vue({
 
                 await Promise.all(Object.values(characters).map(c => c.loadImages()));
 
-                if (this.username === "") this.username = i18n.t("default_user_name");
-
                 if (this.characterId === "naito")
                 {
                     const die = Math.random()
@@ -299,7 +297,7 @@ const vueApp = new Vue({
 
                 const authorSpan = document.createElement("span");
                 authorSpan.className = "message-author";
-                authorSpan.textContent = user.name;
+                authorSpan.textContent = this.toDisplayName(user.name);
 
                 const bodySpan = document.createElement("span");
                 bodySpan.className = "message-body";
@@ -328,7 +326,7 @@ const vueApp = new Vue({
                 if (permission == "granted" && document.visibilityState != "visible" && userId != this.myUserID)
                 {
                     const character = this.users[userId].character
-                    new Notification(user.name + ": " + msg,
+                    new Notification(this.toDisplayName(user.name) + ": " + msg,
                         {
                             icon: "characters/" + character.characterName + "/front-standing." + character.format
                         })
@@ -406,6 +404,7 @@ const vueApp = new Vue({
                 roomList.forEach(r => {
                     r.sortName = i18n.t("room." + r.id, {reading: true});
                     r.streamerCount = r.streamers.length;
+                    r.streamerDisplayNames = r.streamers.map(s => this.toDisplayName(s))
                 })
                 this.roomList = roomList;
                 this.lastRoomListSortKey = null;
@@ -469,6 +468,12 @@ const vueApp = new Vue({
             newUser.isInactive = userDTO.isInactive;
             
             this.users[userDTO.id] = newUser;
+        },
+        toDisplayName: function (name)
+        {
+            if (name == "")
+                return i18n.t("default_user_name");
+            return name;
         },
         drawImage: function (context, image, x, y)
         {
@@ -667,9 +672,9 @@ const vueApp = new Vue({
             for (const o of allObjects.filter(o => o.type == "user"))
             {
                 if (o.o.nameImageWithBackground == null)
-                    o.o.nameImageWithBackground = this.getNameImage(o.o.name, true);
+                    o.o.nameImageWithBackground = this.getNameImage(this.toDisplayName(o.o.name), true);
                 if (o.o.nameImageWithoutBackground == null)
-                    o.o.nameImageWithoutBackground = this.getNameImage(o.o.name, false);
+                    o.o.nameImageWithoutBackground = this.getNameImage(this.toDisplayName(o.o.name), false);
                 
                 const image = this.showUsernameBackground ? o.o.nameImageWithBackground.getImage() : o.o.nameImageWithoutBackground.getImage()
                 
@@ -1018,7 +1023,7 @@ const vueApp = new Vue({
                 const stream = streams[slotId];
                 if (stream.isActive)
                 {
-                    Vue.set(stream, "title", this.users[stream.userId].name);
+                    Vue.set(stream, "title", this.toDisplayName(this.users[stream.userId].name));
                     if (stream.userId == this.myUserID)
                     {
                         this.streamSlotIdInWhichIWantToStream = slotId;

--- a/users.ts
+++ b/users.ts
@@ -28,7 +28,7 @@ export class Player
 
     constructor(options: { name?: string, characterId: string, areaId: Area })
     {
-        if (options.name) this.name = options.name
+        if (typeof options.name === "string") this.name = options.name
         this.characterId = options.characterId
         this.areaId = options.areaId
     }


### PR DESCRIPTION
So that the localised Anonymous/名無しさん name variants don't need to be specified on the server side, I thought it might be better if the username just stays a blank string in the background everywhere. Before the username gets displayed on the client side, it gets fed through this.toDisplayName which changes a blank name to the correct localised version