### PR TITLE
Restrict max 2 logins per IP address per area

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -789,7 +789,7 @@ app.post("/login", (req, res) =>
         
         if (settings.restrictLoginByIp)
         {
-            const users = getUsersByIp(req.ip);
+            const users = getUsersByIp(req.ip, areaId);
             let userCount = users.length;
             users.every(u =>
             {

--- a/index.ts
+++ b/index.ts
@@ -28,7 +28,7 @@ const inactivityTimeout = 30 * 60 * 1000
 
 log.setLevel(log.levels.DEBUG)
 
-if (settings.isUsingProxy)
+if (settings.isBehindProxy)
     app.set('trust proxy', true)
 
 const janusServers: JanusServer[] =

--- a/index.ts
+++ b/index.ts
@@ -790,13 +790,16 @@ app.post("/login", (req, res) =>
         if (settings.restrictLoginByIp)
         {
             const users = getUsersByIp(req.ip);
+            let userCount = users.length;
             users.every(u =>
             {
-                if (users.length < 2) return false;
-                if (u.isGhost) disconnectUser(u);
+                if (userCount < 2) return false;
+                if (!u.isGhost) return true;
+                disconnectUser(u);
+                userCount--;
                 return true;
             })
-            if (users.length > 1)
+            if (userCount > 1)
             {
                 res.statusCode = 500
                 res.json(['error', 'ip_restricted'])

--- a/local-settings.json.example
+++ b/local-settings.json.example
@@ -2,5 +2,7 @@
     "janusServerUrl": "",
     "janusApiSecret": "",
     "janusRoomNamePrefix": "prod",
-    "janusRoomNameIntPrefix": 1
+    "janusRoomNameIntPrefix": 1,
+    "isBehindProxy": true,
+    "restrictLoginByIp": true
 }

--- a/settings.ts
+++ b/settings.ts
@@ -17,4 +17,6 @@ export const settings = {
     janusApiSecret: (fileJsonContents?.janusApiSecret || process.env.GIKO2_JANUS_API_SECRET) as string,
     janusRoomNamePrefix: (fileJsonContents?.janusRoomNamePrefix || process.env.GIKO2_JANUS_ROOM_NAME_PREFIX) as string,
     janusRoomNameIntPrefix: (fileJsonContents?.janusRoomNameIntPrefix || Number.parseInt(process.env.GIKO2_JANUS_ROOM_NAME_INT_PREFIX!)) as number,
+    isUsingProxy: (fileJsonContents?.isUsingProxy || true) as boolean,
+    restrictLoginByIp: (fileJsonContents?.restrictLoginByIp || true) as boolean,
 }

--- a/settings.ts
+++ b/settings.ts
@@ -17,6 +17,6 @@ export const settings = {
     janusApiSecret: (fileJsonContents?.janusApiSecret || process.env.GIKO2_JANUS_API_SECRET) as string,
     janusRoomNamePrefix: (fileJsonContents?.janusRoomNamePrefix || process.env.GIKO2_JANUS_ROOM_NAME_PREFIX) as string,
     janusRoomNameIntPrefix: (fileJsonContents?.janusRoomNameIntPrefix || Number.parseInt(process.env.GIKO2_JANUS_ROOM_NAME_INT_PREFIX!)) as number,
-    isBehindProxy: (fileJsonContents?.isBehindProxy || true) as boolean,
-    restrictLoginByIp: (fileJsonContents?.restrictLoginByIp || true) as boolean,
+    isBehindProxy: fileJsonContents?.isBehindProxy == undefined ? true : fileJsonContents.isBehindProxy,
+    restrictLoginByIp: fileJsonContents?.restrictLoginByIp == undefined ? true : fileJsonContents.restrictLoginByIp,
 }

--- a/settings.ts
+++ b/settings.ts
@@ -17,6 +17,6 @@ export const settings = {
     janusApiSecret: (fileJsonContents?.janusApiSecret || process.env.GIKO2_JANUS_API_SECRET) as string,
     janusRoomNamePrefix: (fileJsonContents?.janusRoomNamePrefix || process.env.GIKO2_JANUS_ROOM_NAME_PREFIX) as string,
     janusRoomNameIntPrefix: (fileJsonContents?.janusRoomNameIntPrefix || Number.parseInt(process.env.GIKO2_JANUS_ROOM_NAME_INT_PREFIX!)) as number,
-    isUsingProxy: (fileJsonContents?.isUsingProxy || true) as boolean,
+    isBehindProxy: (fileJsonContents?.isBehindProxy || true) as boolean,
     restrictLoginByIp: (fileJsonContents?.restrictLoginByIp || true) as boolean,
 }

--- a/static/scripts/lang.js
+++ b/static/scripts/lang.js
@@ -77,7 +77,7 @@ export const messages =
             
             unknown_error: "不明なエラーが原因で接続に失敗しました。",
             invalid_username: "指定されたユーザー名は無効です。",
-            ip_restricted: "このIPアドレスですでに2回ログインしています。",
+            ip_restricted: "すでにこのIPアドレスで2回ログインしています。",
         },
         room:
         {

--- a/static/scripts/lang.js
+++ b/static/scripts/lang.js
@@ -74,6 +74,10 @@ export const messages =
             
             error_obtaining_media_device: "デバイスを取得できませんでした。",
             no_webrtc: "あなたのブラウザーはWebRTCをサポートしていません。",
+            
+            unknown_error: "不明なエラーが原因で接続に失敗しました。",
+            invalid_username: "指定されたユーザー名は無効です。",
+            ip_restricted: "このIPアドレスですでに2回ログインしています。",
         },
         room:
         {
@@ -186,6 +190,10 @@ export const messages =
             
             error_obtaining_media_device: "Unable to obtain media device.",
             no_webrtc: "Sorry, your browser doesn't support WebRTC.",
+            
+            unknown_error: "The connection failed due to an unknown error.",
+            invalid_username: "The provided username is invalid.",
+            ip_restricted: "You are already logged in twice with this IP address.",
         },
         room:
         {

--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -8,6 +8,10 @@ import { messages } from "./lang.js";
 import { RTCPeer, defaultIceConfig } from "./rtcpeer.js";
 import { RenderCache } from "./rendercache.js";
 
+function UserException(message) {
+    this.message = message;
+}
+
 const urlRegex = /(https?:\/\/|www\.)[^\s]+/gi
 
 let loadCharacterImagesPromise = null
@@ -168,10 +172,18 @@ const vueApp = new Vue({
                 this.soundEffectVolume = localStorage.getItem(this.areaId + "soundEffectVolume") || 0
                 this.updateAudioElementsVolume()
             }
-            catch (exc)
+            catch (e)
             {
-                console.log(exc)
-                alert("Connection failed :(")
+                console.error(e)
+                if (e instanceof UserException)
+                {
+                    alert(i18n.t("msg." + e.message))
+                }
+                else
+                {
+                    alert(i18n.t("msg.unknown_error"))
+                }
+                window.location.reload();
             }
         },
         toggleCrispMode: function ()
@@ -285,8 +297,13 @@ const vueApp = new Vue({
                 areaId: this.areaId,
             });
 
-            this.myUserID = await loginResponse.json();
-
+            const loginMessage = await loginResponse.json();
+            
+            if (loginMessage[0] == "error") throw new UserException(loginMessage[1]);
+            if (loginMessage[0] != "success") throw loginMessage;
+            
+            this.myUserID = loginMessage[1];
+            
             // load the room state before connecting the websocket, so that all
             // code handling websocket events (and paint() events) can assume that
             // currentRoom, streams etc... are all defined

--- a/users.ts
+++ b/users.ts
@@ -27,6 +27,7 @@ export class Player
     public isStreaming = false;
     public bubblePosition: Direction = "up";
     public lastRoomMessage: string = "";
+    public ip: string | null = null;
 
     constructor(options: { name?: string, characterId: string, areaId: Area })
     {
@@ -53,6 +54,11 @@ export function getConnectedUserList(roomId: string | null, areaId: string | nul
     if (areaId) output = output.filter(u => u.areaId == areaId)
     return output
 };
+
+export function getUsersByIp(ip: string): Player[]
+{
+    return Object.values(users).filter(u => u.ip == ip)
+}
 
 export function getAllUsers(): Player[]
 {

--- a/users.ts
+++ b/users.ts
@@ -55,9 +55,11 @@ export function getConnectedUserList(roomId: string | null, areaId: string | nul
     return output
 };
 
-export function getUsersByIp(ip: string): Player[]
+export function getUsersByIp(ip: string, areaId: string): Player[]
 {
-    return Object.values(users).filter(u => u.ip == ip)
+    return Object.values(users)
+        .filter(u => u.areaId == areaId)
+        .filter(u => u.ip == ip)
 }
 
 export function getAllUsers(): Player[]

--- a/users.ts
+++ b/users.ts
@@ -27,21 +27,22 @@ export class Player
     public isStreaming = false;
     public bubblePosition: Direction = "up";
     public lastRoomMessage: string = "";
-    public ip: string | null = null;
+    public ip: string;
 
-    constructor(options: { name?: string, characterId: string, areaId: Area })
+    constructor(options: { name?: string, characterId: string, areaId: Area, ip: string })
     {
         if (typeof options.name === "string") this.name = options.name
         this.characterId = options.characterId
         this.areaId = options.areaId
+        this.ip = options.ip
     }
 }
 
 let users: { [id: string]: Player; } = {}
 
-export function addNewUser(name: string, characterId: string, areaId: Area)
+export function addNewUser(name: string, characterId: string, areaId: Area, ip: string)
 {
-    const p = new Player({ name, characterId, areaId });
+    const p = new Player({ name, characterId, areaId, ip });
     users[p.id] = p;
 
     return p;


### PR DESCRIPTION
This adds two new settings:
- If `settings.restrictLoginByIp` is true, you can only login with the same IP address twice. If the IP address is 127.0.0.1, the restrictions are ignored. By default true, but I imagine you'd want to change this to be false for the test heroku instance with an env variable.
- If `settings.isBehindProxy` is true, `app.set('trust proxy', true)` is called which means "the client’s IP address is understood as the left-most entry in the X-Forwarded-* header." so it's accessible from `req.ip`. By default true because both the heroku instances and my maf.moe instance are behind proxies. Hopefully this just works.

In the login request function, all users within the requested area with the requester's IP address are firstly retrieved. In a loop of those users, ghosts are disconnected until there are less than 2 users. If after the loop there is still more than 1 user, a 500 error is sent.

I've also added i18n login rejection messages.
