### PR TITLE
Delay changing direction to allow m**nwalking and sidewalking

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,7 @@ const enforce = require('express-sslify');
 const JanusClient = require('janus-videoroom-client').Janus;
 
 const delay = 0
+const directionChangeDelay = 700;
 const persistInterval = 5 * 1000
 const maxGhostRetention = 5 * 60 * 1000
 const inactivityTimeout = 30 * 60 * 1000
@@ -240,7 +241,9 @@ io.on("connection", function (socket: any)
             log.info("user-move", user.id, direction)
             user.isInactive = false
             user.lastAction = Date.now()
-            if (user.direction != direction)
+            const previousMoveAt = user.lastMovedAt;
+            user.lastMovedAt = Date.now();
+            if (user.direction != direction && user.lastMovedAt - previousMoveAt > directionChangeDelay)
             {
                 // ONLY CHANGE DIRECTION
                 user.direction = direction;

--- a/users.ts
+++ b/users.ts
@@ -20,6 +20,7 @@ export class Player
     public roomId: string = defaultRoom.id;
     public lastAction = Date.now();
     public connectionTime = Date.now();
+    public lastMovedAt = Date.now();
     public disconnectionTime: number | null = null;
     public characterId: string;
     public areaId: Area;


### PR DESCRIPTION
Fixes #28.
- Delay is set to 700ms. At 1000ms, direction cannot be changed if the user does not stop moving :)