### PR TITLE
Fix walking and spinning frame counting for >60fps displays

### DIFF
--- a/static/scripts/user.js
+++ b/static/scripts/user.js
@@ -19,7 +19,7 @@ export default class User
         this.isSpinning = false;
         this.isMoved = true;
         this.direction = "up";
-        this.stepLength = character.characterName == "onigiri" ? 10 : 8;
+        this.stepLength = character.characterName ==  "onigiri" ? (1000/60) * 10 : (1000/60) * 8;
         this.framesUntilNextStep = this.stepLength;
         this.frameCount = 0
         this.isInactive = false;
@@ -93,11 +93,12 @@ export default class User
             this.isSpinning = false;
         }
 
-        this.framesUntilNextStep--
-        if (this.framesUntilNextStep < 0)
-            this.framesUntilNextStep = this.stepLength
+        this.framesUntilNextStep  -= delta;
 
-        this.frameCount++
+        if (this.framesUntilNextStep < 0)
+            this.framesUntilNextStep = this.stepLength;
+
+        this.frameCount += delta;
         if (this.frameCount == Number.MAX_SAFE_INTEGER)
             this.frameCount = 0
     }
@@ -123,7 +124,7 @@ export default class User
 
         if (this.isSpinning)
         {
-            const spinCycle = Math.round(this.frameCount / 2) % 4
+            const spinCycle = Math.round((this.frameCount*60/1000) / 2) % 4
             switch (spinCycle)
             {
                 case 0:
@@ -142,7 +143,7 @@ export default class User
         }
         else if (this.isWalking)
         {
-            const walkCycle = this.framesUntilNextStep > this.stepLength / 2
+            const walkCycle = this.framesUntilNextStep > this.stepLength / 2;
             switch (this.direction)
             {
                 case "up":


### PR DESCRIPTION
This has been bugging me forever, everything seemed way too fast on my 165hz monitor.

The issue was that the game decided you needed to change the walking image every i.e 10 frames, so a 60hz screen would change images 6 times during the walking animation (which is the about the right pace) while the 165hz monitor would see 16 cycles.

Instead of counting frames, we count the time elapsed using delta between each frame, and make the stepLength 10 * (1000/60) aka 10 * (60hz avg delta between frames). Same thing for spinning.

I've tested this and it seems to work fine but it would probably be good to double check on a 60hz monitor that it behaves the same as the old code.