### PR TITLE
ensure that users only get blocked once

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -935,13 +935,16 @@ io.on("connection", function (socket: Socket)
             log.info("user-block", user.id, userId)
             const blockedUser = getUser(userId);
             if (!blockedUser) return; // TODO Return a message to tell the user that the blocking failed
+            
+            // filter out previous blockers and blockees
+            const blockersUserList = getFilteredConnectedUserList(user.roomId, user.areaId)
 
             for (const ip of blockedUser.ips)
                 user.blockedIps.push(ip);
 
             const streams = roomStates[user.areaId][user.roomId].streams;
 
-            getConnectedUserList(user.roomId, user.areaId)
+            blockersUserList
                 .filter((u) => u.socketId && isUserBlocking(user, u))
                 .forEach((u) =>
             {


### PR DESCRIPTION
when you go to block someone, everyone you previously blocked/were blocked by gets sent new user-left-room etc. stuff because you use getConnectedUserList() instead of getFilteredConnectedUserList().
