### PR TITLE
Live subtitles for streams

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,6 +247,11 @@
                             <div class="nico-nico-messages-container"
                                  v-if="streamSlot.isNicoNicoMode">
                             </div>
+                            <div
+                                v-if="streamSlot.withSound && getStreamSubtitleText(index)"
+                                class="stream-subtitles-overlay">
+                                {{ getStreamSubtitleText(index) }}
+                            </div>
                         </div>
                         <div :id="'vu-meter-container-' + index"
                              v-show="streamSlot.isActive
@@ -307,6 +312,11 @@
                                         :default="0"
                                         @value-changed="gain => onGainChanged(index, gain)"></numeric-value-control>
                                 </div>
+                            </div>
+                            <div
+                                v-if="!streamSlot.withVideo && getStreamSubtitleText(index)"
+                                class="audio-stream-subtitles">
+                                {{ getStreamSubtitleText(index) }}
                             </div>
                         </div>
                         <div v-if="streamSlotIdInWhichIWantToStream == index">
@@ -785,6 +795,11 @@
                                 <input type="checkbox" id="preferences-streams-inbound-vu-meter-enabled"
                                     v-model="isStreamInboundVuMeterEnabled" v-on:change="storeSet('isStreamInboundVuMeterEnabled')"><label
                                     for="preferences-streams-inbound-vu-meter-enabled">{{ $t("ui.preferences_streams_inbound_vu_meter_enabled") }}</label>
+                            </div>
+                            <div class='popup-item'>
+                                <input type="checkbox" id="preferences-streams-auto-subtitles-enabled"
+                                    v-model="isStreamAutoSubtitlesEnabled" v-on:change="handleStreamAutoSubtitlesEnabled"><label
+                                    for="preferences-streams-auto-subtitles-enabled">{{ $t("ui.preferences_streams_auto_subtitles_enabled") }}</label>
                             </div>
                         </div>
                         <div class='popup-section'>

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -75,6 +75,7 @@ import {
     getFormattedCurrentDate,
     requestNotificationPermission,
     getDeviceList,
+    getSpeechRecognitionConstructor,
     getClickCoordinatesWithinCanvas,
     htmlToControlChars,
     controlCharsToHtml,
@@ -330,6 +331,7 @@ const vueApp = createApp(defineComponent({
             isCoinSoundEnabled: localStorage.getItem("isCoinSoundEnabled") != "false",
             isStreamAutoResumeEnabled: localStorage.getItem("isStreamAutoResumeEnabled") != "false",
             isStreamInboundVuMeterEnabled: localStorage.getItem("isStreamInboundVuMeterEnabled") != "false",
+            isStreamAutoSubtitlesEnabled: localStorage.getItem("isStreamAutoSubtitlesEnabled") == "true",
             showLogAboveToolbar: localStorage.getItem("showLogAboveToolbar") == "true",
             showLogDividers: localStorage.getItem("showLogDividers") == "true",
             isIgnoreOnBlock: localStorage.getItem("isIgnoreOnBlock") == "true",
@@ -412,6 +414,10 @@ const vueApp = createApp(defineComponent({
             // the key is the slot ID
             inboundAudioProcessors: {} as {[slotId: number]: AudioProcessor},
             outboundAudioProcessor: null as AudioProcessor | null,
+            subtitleRecognizers: {} as {[slotId: number]: any},
+            streamSubtitleRestartTimers: {} as {[slotId: number]: number | null},
+            streamSubtitles: {} as {[slotId: number]: { finalText: string, interimText: string, clearTimer: number | null }},
+            hasShownSubtitleSupportWarning: false,
         }
     },
     provide()
@@ -3054,6 +3060,11 @@ const vueApp = createApp(defineComponent({
                         const audioTrack = this.outboundAudioProcessor.destination.stream.getAudioTracks()[0]
 
                         this.mediaStream.addTrack(audioTrack)
+
+                        if (this.streamSlotIdInWhichIWantToStream !== null)
+                            this.startStreamSubtitleRecognition(
+                                this.streamSlotIdInWhichIWantToStream,
+                                this.outboundAudioProcessor.getProcessedAudioTrack())
                     }
                 }
 
@@ -3189,6 +3200,7 @@ const vueApp = createApp(defineComponent({
 
             this.streamSlotIdInWhichIWantToStream = null;
 
+            this.stopStreamSubtitleRecognition(streamSlotId)
             this.resetRtcPeerSlot(streamSlotId)
 
             // On small screens, displaying the <video> element seems to cause a reflow in a way that
@@ -3269,6 +3281,9 @@ const vueApp = createApp(defineComponent({
                                     setTimeout(() => {this.streams[streamSlotId].isJumping = false}, 100)
                             })
                             await this.inboundAudioProcessors[streamSlotId].initialize()
+                            this.startStreamSubtitleRecognition(
+                                streamSlotId,
+                                this.inboundAudioProcessors[streamSlotId].getProcessedAudioTrack())
                         }
                     }
                     catch (exc)
@@ -3299,6 +3314,8 @@ const vueApp = createApp(defineComponent({
                 await this.inboundAudioProcessors[streamSlotId].dispose()
                 delete this.inboundAudioProcessors[streamSlotId]
             }
+
+            this.stopStreamSubtitleRecognition(streamSlotId)
         },
         async wantToDropStream(streamSlotId: number)
         {
@@ -3451,6 +3468,200 @@ const vueApp = createApp(defineComponent({
             this.wantToStream = false;
             this.streamSlotIdInWhichIWantToStream = null;
         },
+        getStreamSubtitleState(streamSlotId: number)
+        {
+            if (!this.streamSubtitles[streamSlotId])
+            {
+                this.streamSubtitles[streamSlotId] = {
+                    finalText: '',
+                    interimText: '',
+                    clearTimer: null,
+                }
+            }
+            return this.streamSubtitles[streamSlotId]
+        },
+        getStreamSubtitleText(streamSlotId: number)
+        {
+            const subtitleState = this.streamSubtitles[streamSlotId]
+            if (!subtitleState) return ''
+            return [subtitleState.finalText, subtitleState.interimText].filter(Boolean).join(' ')
+        },
+        clearStreamSubtitle(streamSlotId: number)
+        {
+            const subtitleState = this.getStreamSubtitleState(streamSlotId)
+            if (subtitleState.clearTimer)
+                clearTimeout(subtitleState.clearTimer)
+            subtitleState.finalText = ''
+            subtitleState.interimText = ''
+            subtitleState.clearTimer = null
+        },
+        scheduleStreamSubtitleClear(streamSlotId: number)
+        {
+            const subtitleState = this.getStreamSubtitleState(streamSlotId)
+            if (subtitleState.clearTimer)
+                clearTimeout(subtitleState.clearTimer)
+            subtitleState.clearTimer = window.setTimeout(() => {
+                const latestSubtitleState = this.streamSubtitles[streamSlotId]
+                if (!latestSubtitleState) return
+                latestSubtitleState.finalText = ''
+                latestSubtitleState.interimText = ''
+                latestSubtitleState.clearTimer = null
+            }, 7000)
+        },
+        stopStreamSubtitleRecognition(streamSlotId: number)
+        {
+            const restartTimer = this.streamSubtitleRestartTimers[streamSlotId]
+            if (restartTimer)
+            {
+                clearTimeout(restartTimer)
+                this.streamSubtitleRestartTimers[streamSlotId] = null
+            }
+
+            const recognition = this.subtitleRecognizers[streamSlotId]
+            if (recognition)
+            {
+                ;(recognition as any).__gikopoiStopped = true
+                try
+                {
+                    recognition.stop()
+                }
+                catch (exc)
+                {
+                    console.debug(exc)
+                }
+                delete this.subtitleRecognizers[streamSlotId]
+            }
+
+            this.clearStreamSubtitle(streamSlotId)
+        },
+        startStreamSubtitleRecognition(streamSlotId: number, audioTrack: MediaStreamTrack | null)
+        {
+            this.stopStreamSubtitleRecognition(streamSlotId)
+
+            if (!this.isStreamAutoSubtitlesEnabled || !audioTrack || audioTrack.readyState != "live")
+                return
+
+            const SpeechRecognition = getSpeechRecognitionConstructor()
+            if (!SpeechRecognition)
+            {
+                if (!this.hasShownSubtitleSupportWarning)
+                {
+                    this.hasShownSubtitleSupportWarning = true
+                    this.showWarningToast(this.$t("msg.auto_subtitles_not_supported"))
+                }
+                return
+            }
+
+            const subtitleState = this.getStreamSubtitleState(streamSlotId)
+            const recognition = new SpeechRecognition()
+            this.subtitleRecognizers[streamSlotId] = recognition
+
+            recognition.continuous = true
+            recognition.interimResults = true
+            recognition.lang = this.language || navigator.language || "en-US"
+            recognition.maxAlternatives = 1
+
+            recognition.onresult = (event: any) => {
+                if (this.subtitleRecognizers[streamSlotId] !== recognition)
+                    return
+
+                let interimText = ''
+                let latestFinalText = subtitleState.finalText
+
+                for (let i = event.resultIndex || 0; i < event.results.length; i++)
+                {
+                    const transcript = event.results[i][0]?.transcript?.trim()
+                    if (!transcript)
+                        continue
+
+                    if (event.results[i].isFinal)
+                        latestFinalText = transcript
+                    else
+                        interimText += (interimText ? ' ' : '') + transcript
+                }
+
+                subtitleState.finalText = latestFinalText
+                subtitleState.interimText = interimText
+
+                if (latestFinalText)
+                    this.scheduleStreamSubtitleClear(streamSlotId)
+            }
+
+            recognition.onerror = (event: any) => {
+                if (this.subtitleRecognizers[streamSlotId] !== recognition)
+                    return
+
+                if ((event?.error == 'not-allowed' || event?.error == 'service-not-allowed')
+                    && !this.hasShownSubtitleSupportWarning)
+                {
+                    this.hasShownSubtitleSupportWarning = true
+                    this.showWarningToast(this.$t("msg.auto_subtitles_not_supported"))
+                }
+            }
+
+            recognition.onend = () => {
+                if (this.subtitleRecognizers[streamSlotId] !== recognition || (recognition as any).__gikopoiStopped)
+                    return
+
+                if (!this.isStreamAutoSubtitlesEnabled || audioTrack.readyState != "live")
+                    return
+
+                this.streamSubtitleRestartTimers[streamSlotId] = window.setTimeout(() => {
+                    if (this.subtitleRecognizers[streamSlotId] !== recognition)
+                        return
+
+                    try
+                    {
+                        recognition.start(audioTrack)
+                    }
+                    catch (exc)
+                    {
+                        console.debug("Auto subtitle restart failed", exc)
+                    }
+                }, 250)
+            }
+
+            try
+            {
+                recognition.start(audioTrack)
+            }
+            catch (exc)
+            {
+                console.error(exc)
+                delete this.subtitleRecognizers[streamSlotId]
+                if (!this.hasShownSubtitleSupportWarning)
+                {
+                    this.hasShownSubtitleSupportWarning = true
+                    this.showWarningToast(this.$t("msg.auto_subtitles_not_supported"))
+                }
+            }
+        },
+        refreshStreamSubtitleRecognitions()
+        {
+            const activeSlotIds = new Set<number>()
+
+            Object.keys(this.streamSubtitles).forEach(slotId => {
+                this.stopStreamSubtitleRecognition(parseInt(slotId))
+            })
+
+            if (!this.isStreamAutoSubtitlesEnabled)
+                return
+
+            if (this.streamSlotIdInWhichIWantToStream !== null && this.outboundAudioProcessor)
+            {
+                activeSlotIds.add(this.streamSlotIdInWhichIWantToStream)
+                this.startStreamSubtitleRecognition(
+                    this.streamSlotIdInWhichIWantToStream,
+                    this.outboundAudioProcessor.getProcessedAudioTrack())
+            }
+
+            Object.keys(this.inboundAudioProcessors).forEach(slotIdString => {
+                const slotId = parseInt(slotIdString)
+                if (activeSlotIds.has(slotId))
+                    return
+                this.startStreamSubtitleRecognition(slotId, this.inboundAudioProcessors[slotId].getProcessedAudioTrack())
+            })
+        },
         changeStreamVolume(streamSlotId: number)
         {
             const volumeSlider = document.getElementById("volume-" + streamSlotId) as HTMLInputElement
@@ -3534,6 +3745,7 @@ const vueApp = createApp(defineComponent({
         {
             this.storeSet('language');
             this.setLanguage();
+            this.refreshStreamSubtitleRecognitions()
         },
         storeSet(itemName: string, value?: any)
         {
@@ -3692,6 +3904,11 @@ const vueApp = createApp(defineComponent({
         {
             this.storeSet('customMentionSoundPattern')
             this.setMentionRegexObjects()
+        },
+        handleStreamAutoSubtitlesEnabled()
+        {
+            this.storeSet('isStreamAutoSubtitlesEnabled')
+            this.refreshStreamSubtitleRecognitions()
         },
         handleEnableTextToSpeech()
         {

--- a/src/frontend/style/main.css
+++ b/src/frontend/style/main.css
@@ -860,6 +860,35 @@ button.checked {
     transition: opacity 0.3s;
 }
 
+.stream-subtitles-overlay
+{
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 2;
+    padding: 6px 8px;
+    background: rgba(0, 0, 0, 0.72);
+    color: white;
+    text-align: center;
+    text-shadow: 0 1px 2px black;
+    font-size: 14px;
+    line-height: 1.35;
+    word-break: break-word;
+    pointer-events: none;
+}
+
+.audio-stream-subtitles
+{
+    margin-top: 6px;
+    padding: 4px 6px;
+    background: rgba(0, 0, 0, 0.72);
+    color: white;
+    font-size: 12px;
+    line-height: 1.35;
+    word-break: break-word;
+}
+
 .video-container:hover > .pin-video-button
 {
     /* visibility: visible; */

--- a/src/frontend/utils.ts
+++ b/src/frontend/utils.ts
@@ -199,6 +199,29 @@ const AudioContext = window.AudioContext          // Default
 
 export type VuMeterCallback = (level: number) => void
 
+export interface SpeechRecognitionLike
+{
+    continuous: boolean
+    interimResults: boolean
+    lang: string
+    maxAlternatives?: number
+    onresult: ((event: any) => void) | null
+    onerror: ((event: any) => void) | null
+    onend: (() => void) | null
+    start: (audioTrack?: MediaStreamTrack) => void
+    stop: () => void
+    abort?: () => void
+}
+
+type SpeechRecognitionConstructor = new () => SpeechRecognitionLike
+
+export function getSpeechRecognitionConstructor(): SpeechRecognitionConstructor | null
+{
+    return (window as any).SpeechRecognition
+        || (window as any).webkitSpeechRecognition
+        || null
+}
+
 export class AudioProcessor
 {
     private stream: MediaStream
@@ -306,6 +329,11 @@ export class AudioProcessor
                     window.clearInterval(this.vuMeterTimer)
             }
         }, 100)
+    }
+
+    getProcessedAudioTrack(): MediaStreamTrack | null
+    {
+        return this.destination.stream.getAudioTracks()[0] || null
     }
 
     async dispose(): Promise<void>

--- a/src/lang.d.ts
+++ b/src/lang.d.ts
@@ -1,1 +1,2 @@
 declare module "*.json5"
+declare module "*.css"

--- a/src/langs/en.json5
+++ b/src/langs/en.json5
@@ -138,6 +138,7 @@
         preferences_title_streams: "Streams",
         preferences_streams_auto_resume: "Auto resume",
         preferences_streams_inbound_vu_meter_enabled: "Display VU meter for received streams",
+        preferences_streams_auto_subtitles_enabled: "Automatic subtitles (experimental, Chromium browsers)",
         preferences_title_chat: "Chat",
         preferences_clear_log: "Clear chat log",
 
@@ -182,6 +183,7 @@
         error_obtaining_media: "Unable to obtain media. Please check the browser permissions.",
         error_obtaining_video: "Unable to obtain video. Please check the browser permissions.",
         error_obtaining_audio: "Unable to obtain audio. Please check the browser permissions.",
+        auto_subtitles_not_supported: "Automatic subtitles for stream audio are only available in supported Chromium-based browsers.",
         no_webrtc: "Sorry, your browser doesn't support WebRTC.",
         error_didnt_select_device: "Please select a device.",
         

--- a/src/langs/ja.json5
+++ b/src/langs/ja.json5
@@ -138,6 +138,7 @@
         preferences_title_streams: "配信",
         preferences_streams_auto_resume: "配信再開後に自動受信",
         preferences_streams_inbound_vu_meter_enabled: "受信側音量ゲージを表示",
+        preferences_streams_auto_subtitles_enabled: "自動字幕（実験中・Chromium系のみ）",
         preferences_title_chat: "チャット",
         preferences_clear_log: "チャットログをクリア",
 
@@ -182,6 +183,7 @@
         error_obtaining_media: "メディアを取得できませんでした。ブラウザの許可を確認してください。",
         error_obtaining_video: "動画を取得できませんでした。ブラウザの許可を確認してください。",
         error_obtaining_audio: "音声を取得できませんでした。ブラウザの許可を確認してください。",
+        auto_subtitles_not_supported: "配信音声の自動字幕は、対応しているChromium系ブラウザでのみ使えます。",
         no_webrtc: "このブラウザはWebRTCをサポートしていません。",
         error_didnt_select_device: "デバイスを選択してください。",
 


### PR DESCRIPTION
This is a sloppy AI generated live subtitles feature.

## Problems:
- It seems to be working only on chromium browsers. Would be nice to find a way to make it work on other browsers as well.
- Only works for english (support for other languages can be added, apparently)
- enabling/disabling subtitles is a preference, but it might be better to have it as a flag directly in the stream panel?

## Possible solutions:
- Have the streamer generate the subs on his side and send them to everyone else through the websockets. Rationale: I get the impression that all browsers support speech2text given that the audio source is a local microphone, rather than a generic MediaStream.
- Or maybe subtitles should be generated server side? Probably difficult to do before the refactoring that removes janus.
